### PR TITLE
Add Compact Post Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ INSTAGRAM_USERNAME=<your_instagram_username>
 ```bash
 python bin/fetch_instagram_session.py
 ```
+
+### Additional Options
+
+| Env Var           | Default Value | Description                                                                                                              |
+|-------------------|---------------|--------------------------------------------------------------------------------------------------------------------------|
+| `MINIMALIST_POST` | false         | If set to true, only the url and video will post instead of additional details such as description, author, created, etc |
+|                   |               |                                                                                                                          |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # discord-video-embed-bot
+
 A Discord bot that automatically embeds media and metadata of messages containing a link of a supported platform.
 
 ![image](https://github.com/amadejkastelic/discord-video-embed-bot/assets/26391003/bada7a36-db0d-44ba-89ee-afe4f79ad7d3)
 
-
 ## Supported platforms
+
 - Instagram ✅
 - Facebook ✅
 - Tiktok ✅
@@ -13,17 +14,23 @@ A Discord bot that automatically embeds media and metadata of messages containin
 - Youtube Shorts ✅
 
 ## How to run
-- Build the docker image: `docker build . -t video-embed-bot` or simply pull it from ghcr:
+
+Build the docker image: `docker build . -t video-embed-bot` or simply pull it from ghcr:
+
 ```bash
 docker pull ghcr.io/amadejkastelic/discord-video-embed-bot:<latest|tag>
 ```
-- Run it with your discord api key: `docker run -e DISCORD_API_TOKEN=<api_token> video-embed-bot`
+
+Run it with your discord api key: `docker run -e DISCORD_API_TOKEN=<api_token> video-embed-bot`
 
 ### Facebook
+
 Facebook requires you to provide cookies. Download them in your browser using [an extension](https://chrome.google.com/webstore/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc) while you're logged in and mount them to the container).
 
 ### Reddit
-- For extended reddit support you need to create an app on reddit and add the following environment variables:
+
+For extended reddit support you need to create an app on reddit and add the following environment variables:
+
 ```bash
 REDDIT_API_TOKEN=<your_reddit_api_token>
 REDDIT_API_SECRET=<your_reddit_api_secret>
@@ -31,7 +38,9 @@ REDDIT_USER_AGENT=<name_version_and_your_username>
 ```
 
 ### Twitter
-- For better twitter support you need to add credentials:
+
+For better twitter support you need to add credentials:
+
 ```bash
 TWITTER_USERNAME=<your_twitter_username>
 TWITTER_EMAIL=<your_twitter_email>
@@ -39,19 +48,24 @@ TWITTER_PASSWORD=<your_twitter_password>
 ```
 
 ### Instagram
-- For better instagram integration that allows to view items that require login, you need to provide the instagram.sess file and instagram username environemnt variable:
+
+For better instagram integration that allows to view items that require login, you need to provide the instagram.sess file and instagram username environemnt variable:
+
 ```bash
 INSTAGRAM_USERNAME=<your_instagram_username>
 ```
-- `instagram.sess` file should be in the working directory of your instance
-- You can obtain the session file by logging into Instagram in Firefox and running:
+
+`instagram.sess` file should be in the working directory of your instance
+
+You can obtain the session file by logging into Instagram in Firefox and running:
+
 ```bash
 python bin/fetch_instagram_session.py
 ```
 
 ### Additional Options
 
-| Env Var           | Default Value | Description                                                                                                              |
-|-------------------|---------------|--------------------------------------------------------------------------------------------------------------------------|
-| `MINIMALIST_POST` | false         | If set to true, only the url and video will post instead of additional details such as description, author, created, etc |
-|                   |               |                                                                                                                          |
+| Env Var        | Default Value | Description                                                                                                              |
+|----------------|---------------|--------------------------------------------------------------------------------------------------------------------------|
+| `COMPACT_POST` | false         | If set to true, only the url and video will post instead of additional details such as description, author, created, etc |
+|                |               |                                                                                                                          |

--- a/models/post.py
+++ b/models/post.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import io
 import typing
 from dataclasses import dataclass
@@ -14,9 +15,13 @@ class Post:
     buffer: typing.Optional[io.BytesIO] = None
     spoiler: bool = False
     created: typing.Optional[datetime.datetime] = None
+    minimalist_post = os.environ.get('MINIMALIST_POST') or 'false'
 
     def __str__(self) -> str:
         description = self.description or '❌'
+
+        if self.minimalist_post:
+            return ('🔗 URL: {url}\n').format(url=self.url)
 
         return (
             '🔗 URL: {url}\n'

--- a/models/post.py
+++ b/models/post.py
@@ -15,12 +15,12 @@ class Post:
     buffer: typing.Optional[io.BytesIO] = None
     spoiler: bool = False
     created: typing.Optional[datetime.datetime] = None
-    minimalist_post = os.environ.get('MINIMALIST_POST') or 'false'
+    compact_post = os.environ.get('COMPACT_POST') or 'false'
 
     def __str__(self) -> str:
         description = self.description or '❌'
 
-        if self.minimalist_post:
+        if self.compact_post:
             return ('🔗 URL: {url}\n').format(url=self.url)
 
         return (


### PR DESCRIPTION
**Purpose:**
Content creators can be extremely annoying with posting 30+ hashtags per video or other useless long information. Adding this feature I think will be beneficial for if someone just wanted the URL (in case it false to load) and the video itself. 

**Requirement:**
- Include the `COMPACT_POST` environment variable (true / false)

**Additional:**
In updating the README, I added a table that describes the additional options. This allows for the project to grow in some of the options available. Also while in here, I did a little clean up based on linting suggestions. Hope that is okay.

I'm very green to Python other than training videos and small projects, so please feel free to give advice or suggestions.